### PR TITLE
Fix TypeScript ignore and add secure and sameSite options to refresh_token cookie

### DIFF
--- a/app/token/page.tsx
+++ b/app/token/page.tsx
@@ -17,7 +17,7 @@ const GetTokenParams = () => {
     useEffect(() => {
         if (access_token && refresh_token) {
             setToken(access_token);
-            cookies.set('refresh_token', refresh_token)
+            cookies.set('refresh_token', refresh_token, {secure:true, sameSite:'Lax'})
             router.push("/");
         }else{
             alert('로그인에 실패했습니다.')

--- a/next.config.js
+++ b/next.config.js
@@ -1,4 +1,17 @@
 /** @type {import('next').NextConfig} */
-const nextConfig = {}
-
-module.exports = nextConfig
+const nextConfig = {
+    eslint: {
+      // Warning: This allows production builds to successfully complete even if
+      // your project has ESLint errors.
+      ignoreDuringBuilds: true,
+    },
+    typescript: {
+      // !! WARN !!
+      // Dangerously allow production builds to successfully complete even if
+      // your project has type errors.
+      // !! WARN !!
+      ignoreBuildErrors: true,
+    },
+  };
+  
+  module.exports = nextConfig;


### PR DESCRIPTION
This pull request fixes an issue with TypeScript ignore and adds secure and sameSite options to the refresh_token cookie. The changes include updating the `cookies.set` method in the `GetTokenParams` function to include the `secure` and `sameSite` options, and adding configuration options to the `nextConfig` object to ignore TypeScript errors during builds and allow production builds to complete even if there are type errors.