### PR TITLE
Fix atom to localstorage room_id when end_game

### DIFF
--- a/app/gamePage/page.tsx
+++ b/app/gamePage/page.tsx
@@ -138,8 +138,9 @@ export default function QR() {
         }
 
         const handleBeforeUnload = () => {
+            const user_t = JSON.parse(localStorage.getItem('userInfo')|| 'null');
             socket.current.emit('end_game', {
-                room_id: userInfo.id,
+                room_id: user_t.id
             });
 
         };


### PR DESCRIPTION
현재 구현은 올바른 user_t.id 값을 사용하는 대신에 userInfo.id 값을 사용하고 있었습니다. 이로 인해 잘못된 데이터가 서버로 전송되었습니다.

이 문제를 해결하기 위해 코드가 업데이트되어 서버로 end_game 이벤트를 보낼 때 올바른 user_t.id 값을 사용하도록 수정되었습니다.

이 Pull Request는 다음 커밋에 대응합니다:

fix(gamePage): fix atom to localstorage room_id, when end_game
이 Pull Request가 좋아 보인다면 리뷰하고 병합해주세요.