### PR TITLE
게임이 끝나거나 나갔을 때 뒤로가기 기능 막기

### DIFF
--- a/app/catchAnswer/page.tsx
+++ b/app/catchAnswer/page.tsx
@@ -36,12 +36,7 @@ export default function CatchAnswer() {
                 socket.current.disconnect()
                 alert('정답이 설정되었습니다.')
 
-                if (window.opener && window.opener !== window) {
-                    window.opener.location.reload(); // Reload the parent window
-                    window.close(); // Close the current window
-                } else {
-                    window.location.href = 'about:blank'; // Navigate to a blank page
-                }
+                window.close();
 
             } else {
                 alert('아직 방이 안 만들어졌습니다.')

--- a/app/gamePage/page.tsx
+++ b/app/gamePage/page.tsx
@@ -92,23 +92,6 @@ export default function QR() {
             setNowPeople(res.player_cnt)
         });
 
-        // socket.current.on('player_list_add', (res)=>{
-        //     console.log(res)
-        //     let recieved_people = res.player_cnt
-        //     setNowPeople(recieved_people)
-        //     socket.current.emit('player_list_add_check', {
-        //         cur_num : recieved_people,
-        // })
-        // });
-
-        // socket.current.on('player_list_remove', (res)=>{
-        //     console.log(res)
-        //     let recieved_people = res.player_cnt
-        //     setNowPeople(recieved_people)
-        //     socket.current.emit('player_list_add_check', {
-        //         cur_num : recieved_people,
-        // })
-
 
         return () => { 
             handleBeforeUnload();

--- a/app/player/page.tsx
+++ b/app/player/page.tsx
@@ -10,7 +10,6 @@ import { socketApi } from '../modules/socketApi';
 import useVH from 'react-viewport-height';
 import { Alert } from '@mui/material';
 import {isMobile, browserName} from 'react-device-detect';
-import { useThemeDetector } from '@/customHook/useThemeDetector';
 
 
 
@@ -49,12 +48,7 @@ export default function Player() {
         socket.current.on("end", (res) => {
             if (res.result === true) {
                 alert('게임이 종료되었습니다.')
-                if (window.opener && window.opener !== window) {
-                    window.opener.location.reload(); // Reload the parent window
-                    window.close(); // Close the current window
-                } else {
-                    window.location.href = 'about:blank'; // Navigate to a blank page
-                }
+                window.close();
             }
         })
 

--- a/app/playerComponent/catchPlayer.tsx
+++ b/app/playerComponent/catchPlayer.tsx
@@ -10,12 +10,13 @@ export default function CatchPlayer({ roomId, socket }: { roomId: string, socket
         if (confirm('게임을 나가시겠습니까?')) {
             socket.emit("leave_game", {
             });
-            if (window.opener && window.opener !== window) {
-                window.opener.location.reload(); // Reload the parent window
-                window.close(); // Close the current window
-            } else {
-                window.location.href = 'about:blank'; // Navigate to a blank page
-            }
+            // if (window.opener && window.opener !== window) {
+            //     window.opener.location.reload(); // Reload the parent window
+            //     window.close(); // Close the current window
+            // } else {
+            //     window.location.href = 'about:blank'; // Navigate to a blank page
+            // }
+            window.close();
         }
     }
     //throw catch mind answer (blocks the button for 3 seconds)


### PR DESCRIPTION
# 문제 정의
기존 코드는 
1. 호스트의 모바일폰에서 정답을 설정하거나 
2. 플레이어가 나가기를 누르거나 
3. 게임이 종료되었을 때 플레이어의 폰에서
about-blank가 뜨도록 되어있었다.
이로 인해 사용자가 뒤로가기를 누르면 다시 소켓에 접속할 수 있는 문제가 있었다.

# 문제 해결
`window.close();`
위 코드를 이용하여 about-blank로 가는 대신 탭이 꺼지게 바꾸었다.

close #64