### PR TITLE
플레이어가 실수로 새로고침하는 것을 방지 & 레디상태에서 타임아웃이 발생하면 레디가 풀리게

### DIFF
--- a/app/gamePage/page.tsx
+++ b/app/gamePage/page.tsx
@@ -187,7 +187,7 @@ export default function QR() {
 
                         <div className='gameInfo-start-button'>
                             <Button disabled={nowPeople === 0} onClick={startGame}>게임 시작</Button>
-                            {/* <Button onClick={testGame}>Test</Button> */}
+                            <Button onClick={testGame}>Test</Button>
                         </div>
                     </div>
                     <style jsx>{`

--- a/app/globals.css
+++ b/app/globals.css
@@ -9,5 +9,4 @@ body {
   /* off-white background */
   background-color: #f8f8f8 !important;
   box-sizing: border-box;
-  overflow: hidden;
 };

--- a/app/globals.css
+++ b/app/globals.css
@@ -9,4 +9,5 @@ body {
   /* off-white background */
   background-color: #f8f8f8 !important;
   box-sizing: border-box;
+  overflow: hidden;
 };

--- a/app/player/page.tsx
+++ b/app/player/page.tsx
@@ -9,7 +9,7 @@ import { v4 as uuidv4 } from 'uuid';
 import { socketApi } from '../modules/socketApi';
 import useVH from 'react-viewport-height';
 import { Alert } from '@mui/material';
-import {isMobile, browserName} from 'react-device-detect';
+import { isMobile, browserName } from 'react-device-detect';
 
 
 
@@ -52,6 +52,11 @@ export default function Player() {
             }
         })
 
+        socket.current.on("forceDisconnect", (res) => {
+            alert('게임이 15분동안 시작되지 않아 종료되었습니다.')
+            setReady(false)
+        })
+
         socket.current.on("ready", (res) => {
             if (res.result === true) {
                 // alert('ready')
@@ -65,6 +70,7 @@ export default function Player() {
         if (isMobile && (browserName === 'Samsung Internet')) {
             alert("삼성 브라우저에서는 다크모드를 사용하실 경우 캐치마인드 게임이 어렵습니다.\n다크모드를 사용중이실 경우 해제하고 게임을 즐겨주세요!");
         }
+
         return () => {
             socket.current.emit("leave_game", {
             });
@@ -92,9 +98,9 @@ export default function Player() {
 
 
     return (
-        <>{isGame?
+        <>{isGame ?
             //캐치마인드 게임이 시작되면 catch로 이동
-            <CatchPlayer roomId={room_id as string} socket={socket.current}/>:
+            <CatchPlayer roomId={room_id as string} socket={socket.current} /> :
             //무궁화꽃이피었습니다 게임이 시작되면 flower로 이동
             <>
                 <div className="nickname-container">
@@ -104,20 +110,20 @@ export default function Player() {
                             <span className='teamdef'>Team.def():</span>
                         </div>
                     </div>
-                    <div className='alertDiv'><Alert severity={ready?"success":"info"}>{ready?"잠시 기다려 주시면 게임이 곧 시작됩니다!\n 닉네임을 변경하시려면 '준비 취소'를 누르신 후 변경해주세요!":"닉네임을 입력하신 후 '준비 완료!' 버튼을 눌러주세요!"}</Alert></div>
+                    <div className='alertDiv'><Alert severity={ready ? "success" : "info"}>{ready ? "잠시 기다려 주시면 게임이 곧 시작됩니다!\n 닉네임을 변경하시려면 '준비 취소'를 누르신 후 변경해주세요!" : "닉네임을 입력하신 후 '준비 완료!' 버튼을 눌러주세요!"}</Alert></div>
                     <div className='nickDiv'>
-                    <label className="nickname-label">닉네임: </label>
-                    <input
-                        type="text"
-                        className="nickname-input"
-                        value={playerNickname ?? ''}
-                        onChange={(e) => setPlayerNickname(e.target.value)}
-                        disabled={ready}
-                        placeholder='닉네임을 입력해주세요.'
-                    />
-                    <Button variant={ready ? "outlined" : "contained"} className="nickname-change" onClick={ready ? cancleReady : readyToPlay}>
-                        {ready ? "준비 취소!" : "준비 완료!"}
-                    </Button></div>
+                        <label className="nickname-label">닉네임: </label>
+                        <input
+                            type="text"
+                            className="nickname-input"
+                            value={playerNickname ?? ''}
+                            onChange={(e) => setPlayerNickname(e.target.value)}
+                            disabled={ready}
+                            placeholder='닉네임을 입력해주세요.'
+                        />
+                        <Button variant={ready ? "outlined" : "contained"} className="nickname-change" onClick={ready ? cancleReady : readyToPlay}>
+                            {ready ? "준비 취소!" : "준비 완료!"}
+                        </Button></div>
                 </div></>}
             <style jsx>{`
                 .nickname-container {

--- a/app/player/page.tsx
+++ b/app/player/page.tsx
@@ -71,6 +71,8 @@ export default function Player() {
             alert("삼성 브라우저에서는 다크모드를 사용하실 경우 캐치마인드 게임이 어렵습니다.\n다크모드를 사용중이실 경우 해제하고 게임을 즐겨주세요!");
         }
 
+        // window.addEventListener('resize', useVH);
+
         return () => {
             socket.current.emit("leave_game", {
             });
@@ -193,6 +195,11 @@ export default function Player() {
                     font-size: 22px;
                     font-weight: 500;
                     color: gray;
+                }
+            `}</style>
+            <style jsx global>{`
+                body {
+                    overflow: hidden !important;
                 }
             `}</style>
         </>


### PR DESCRIPTION
플레이어가 실수로 새로고침하는 것을 방지

# 문제 정의
플레이어가 게임 중 탭을 닫거나 새로고침을 하면 그 플레이어는 게임에 참여중이 아님에도 불구하고 게임 룸에 남게 된다. 이를 해결하기 위해 플레이어가 새로고침을 하거나 탭을 닫으려 하면 막아지게 하려 하였다.

# 해결방안
데스크탑 브라우저에서 새로고침을 막거나 뒤로가기를 막을 순 있어도 모바일에서는 뒤로가기나 새로고침을 막을 순 없었다.

때문에 브라우저에서 플레이어가 실수로 위로 혹은 아래로 당겨서 새로고침 되는 것을 막기라도 하기 위해 global.css 파일의 body에 overflow:hidden을 주었다.

# 해결방안 수정
위 방법대로 하니까 호스트의 데스크탑 화면에도 스크롤이 먹히지 않는 문제점이 발생하였다.
때문에 global.css의 body{overflow:hidden} 을 제거하고 player/page 에 아래와 같이 추가하였다.
```
<style jsx global>{`
                body {
                    overflow: hidden !important;
                }
            `}</style>
```

이미 정의된 style 태그가 있긴 하지만, 그 태그는 글로벌이 아니기 때문에 새로 글로벌 태그를 사용하였다.

close #68

===========================================================================

레디상태에서 타임아웃이 발생하면 레디가 풀리게

# 문제 정의
기존에는 호스트가 게임 방을 만들고 15분동안 게임 시작을 안 해도 플레이어들은 게임 방에서 나가지지 않았다. 

# 문제 해결
지금은 호스트 타임아웃이 발생하면 플레이어들은 준비 완료 한것이 풀어지고 방 타임아웃이 발생했다고 alert를 받는다.
```
useEffect(() => {
...
socket.current.on("forceDisconnect", (res) => {
            alert('게임이 15분동안 시작되지 않아 종료되었습니다.')
            setReady(false)
        })
...
}, []);
```

사용성을 고려해서 플레이어의 게임 창이 꺼지지는 않게 했다.
이로 인해 호스트가 다시 방을 만들면 qr을 찍을 필요가 없다.

close #70

