### PR TITLE
호스트 모바일로 접속하면 catchAnswer 에만 들어가지게

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -11,6 +11,7 @@ import { useEffect } from 'react';
 import { useCookies } from 'next-client-cookies';
 import { myApi } from './modules/backApi';
 import { gameAtoms } from './modules/gameAtoms';
+import {isMobile, isTablet} from 'react-device-detect';
 
 
 export default function Home() {
@@ -22,8 +23,10 @@ export default function Home() {
   const cookies = useCookies();
 
   useEffect(() => {
-    if(!cookies.get('refresh_token'))
+    if(!cookies.get('refresh_token')){
+      checkIsHostPhone()
       return
+    }
     const acc_token : string = localStorage.getItem('access_token')??''
     // console.log("acc_token: ")
     // console.log(acc_token)
@@ -55,6 +58,7 @@ export default function Home() {
       .catch((res) => {
         // console.log("checkLogin2 error")
         alert('로그인에 실패했습니다. 다시 로그인해주세요.\n 문제가 있을 시 캐시를 삭제해보세요.')
+        checkIsHostPhone()
       })
   }
 
@@ -81,7 +85,6 @@ export default function Home() {
             sendRefresh()
         }
         else {
-          alert(res)
           setToken('');
         setUserInfo({
             id: '',
@@ -93,6 +96,7 @@ export default function Home() {
         cookies.remove('refresh_token')
         setIsLogin(false);
         setGame(["",null])
+        checkIsHostPhone()
         }
       })
   }
@@ -128,15 +132,17 @@ export default function Home() {
         cookies.remove('refresh_token')
         setIsLogin(false);
         setGame(["",null])
-        router.push("/")
+        if(isMobile){
+          router.push("/catchAnswer");
+        }
+        else router.push("/")
       })
   }
 
 
 
   const checkIsHostPhone = () => {
-    let isHostPhone = localStorage.getItem('isHostPhone');
-    if(isHostPhone === 'true'){
+    if(isMobile){
       router.push("/catchAnswer");
     }
   }

--- a/app/playerComponent/catchPlayer.tsx
+++ b/app/playerComponent/catchPlayer.tsx
@@ -79,6 +79,10 @@ export default function CatchPlayer({ roomId, socket }: { roomId: string, socket
             alert(`우승자 : ${res.nickname}\n정답 : ${res.answer}`)
         })
 
+        socket.on('incorrect', (res) => {
+            alert('정답이 아닙니다.')
+        })
+
 
         return () => {
             // 컴포넌트가 언마운트될 때 Socket.io 연결 해제

--- a/component/footer.tsx
+++ b/component/footer.tsx
@@ -18,25 +18,16 @@ export interface ModalProps {
 
 export default function Footer() {
     const [open, setOpen] = useState<ModalProps['isOpen']>(false);
-    const [isLogin, setIsLogin] = useAtom(loginAtom)
     const currentPath = usePathname()
-    const hideHeader = currentPath === '/player'||'catchAnswer' ? true : false
+    const hideHeader = (currentPath === '/player'|| currentPath === '/catchAnswer') ? true : false
 
     const handleClose = () => { setOpen(false); }
-    const catch_answer = () => { setOpen(true); }
 
     return (<>{hideHeader?'':<>
         <div className="footerContainer">
             <div>
                 <h4>SWJUNGLE Team.def()</h4>
             </div>
-        {/* 더 이상 사용하지 않는 기능 */}
-            {isLogin?
-            <div>
-                {/* 캐치마인드 정답 제출용 모달 호출 버튼 */}
-                <Button onClick={catch_answer}> </Button>
-            </div>
-            :null}
             
 
         </div>

--- a/component/header.tsx
+++ b/component/header.tsx
@@ -13,6 +13,7 @@ import Image from 'next/image';
 import { useCookies } from 'next-client-cookies';
 import { gameAtoms } from "@/app/modules/gameAtoms";
 import { usePathname } from 'next/navigation';
+import {isMobile} from 'react-device-detect';
 
 export interface ModalProps {
     isOpen: boolean,
@@ -76,6 +77,10 @@ export default function Header() {
         setGame(["", null])
         localStorage.removeItem('isHostPhone')
         alert("로그아웃 되었습니다.");
+        if(isMobile){
+            window.open("about:blank", "_self");
+            window.close();
+        }
         router.push("/");
     }
 
@@ -98,7 +103,7 @@ export default function Header() {
                     <div>{userInfo.nickname}님
                     </div>
                 </div>
-                : null}
+                : <div></div>}
             {/* 로그인 버튼 */}
             <div className='no-login'>
                 <Button onClick={isLogin ? handleLogout : handleOpenLogin}>{isLogin ? "로그아웃" : "로그인 / 회원가입"}</Button>


### PR DESCRIPTION
# 문제 정의
기존에는 catchAnser로 들어오는 상황은 모바일밖에 없겠다고 판단하여 catchAnswer에 진입 즉시 localStorage를 이용하여 isHostMobile에 true를 준 다음, 홈 화면에 들어서는 순간 만약 localStorage의 isHostMobile이 true면 무조건 catchAnswer로 이동이 되게 강제하였다.

그러나 이렇게 하니 데스크탑에서 host가 주소창에 catchAnswer 루트로 쳐서 들어가게 되면 다시 home으로 나갈 수 없는 문제가 발생하였다.

나가는 방법은 로그아웃을 하고 다시 집입하거나 개발자 도구를 켜서 localStorage의 isHostMobile을 false로 임의로 바꾸는 방법밖에 없었는데, 이는 host에게 무리가 있어 보였다.

# 해결 방법
'react-device-detect'를 사용하여 host 화면이 모바일 일 때는 무조건 catchAnswer로 가지게 강제하였다.
또한 모바일 상태로는 home으로 갈 수 없게 하였다.
이로 인해 host가 catchAnswer에 납치되어 나올 수 없는 일을 방지하였다.
+ 추가적으로 catchAnswer에서 로그인창이 뜨는 방식을 Modal로 변경하였고, catchAnwer의 header를 수정하여 홈으로 가는 모든 방법을 차단하였다.

# 고려해야 할 부분
다만 isMobile에 태블릿도 포함이 되어 태블릿으로 접속 시 또한 무조건 catchAnswer로 들어가지는 문제가 발생하였다.
추후 여유가 된다면 수정 예정이다.

close #76