### PR TITLE
캐치마인드 게임종료 api(end_game)에 guard(session guard) 추가 

### DIFF
--- a/app/catch/page.tsx
+++ b/app/catch/page.tsx
@@ -8,6 +8,7 @@ import MyModal from '@/component/MyModal';
 import IntegrationNotistack from '@/component/snackBar';
 import { answerAtom } from '../modules/answerAtom';
 import { Socket } from 'socket.io-client';
+import { tokenAtoms } from '../modules/tokenAtoms';
 
 interface recievedAns {
   ans: string;
@@ -29,6 +30,7 @@ export default function Catch({socket}: {socket : Socket}) {
   const [eraserWidth, setEraserWidth] = useState(45);
   const [isEraser, setIsEraser] = useState(false);
   const [userInfo,] = useAtom(userInfoAtoms)
+  const [acc_token,] = useAtom(tokenAtoms)
   const router = useRouter();
   const [answer, setAnswer] = useState('');
   const [correctNick, setCorrectNick] = useState('');
@@ -93,6 +95,7 @@ export default function Catch({socket}: {socket : Socket}) {
   const handleBeforeUnload = () => {
     const user_t = JSON.parse(localStorage.getItem('userInfo')|| 'null');
     socket.emit('end_game', {
+        access_token: acc_token,
         room_id: user_t.id
     });
 
@@ -224,6 +227,7 @@ export default function Catch({socket}: {socket : Socket}) {
 
       if(confirm("게임을 나가시겠습니까?")){
         socket.emit('end_game',{
+          access_token: acc_token,
           room_id : userInfo.id,
         });
 
@@ -237,6 +241,7 @@ export default function Catch({socket}: {socket : Socket}) {
     } else {
 
       socket.emit('end_game',{
+        access_token: acc_token,
         room_id : userInfo.id,
       });
 

--- a/app/gamePage/page.tsx
+++ b/app/gamePage/page.tsx
@@ -134,6 +134,7 @@ export default function QR() {
         const handleBeforeUnload = () => {
             const user_t = JSON.parse(localStorage.getItem('userInfo')|| 'null');
             socket.current.emit('end_game', {
+                access_token: token,
                 room_id: user_t.id
             });
 


### PR DESCRIPTION
백 서버에서 socket.io 로 'end_game' 을 on 할 때 guard(session)을 추가 할 예정이므로 프론트엔드에도 'end_game'으로 Emit 할 때 access_token을 같이 보내도록 수정함

close #38