### PR TITLE
#103, #106, #85 수정

### DIFF
--- a/app/catchAnswer/page.tsx
+++ b/app/catchAnswer/page.tsx
@@ -26,7 +26,7 @@ export default function CatchAnswer() {
     const vh = useVH();
     const [open, setOpen] = useState<boolean>(!isLogin);
 
-    const socket = useRef(io(`${socketApi}?uuId=${uuId}`,{
+    const socket = useRef(io(`${socketApi}/catch?uuId=${uuId}`,{
         withCredentials: true,
         transports: ["websocket"],
         autoConnect: false,

--- a/app/gamePage/page.tsx
+++ b/app/gamePage/page.tsx
@@ -25,7 +25,6 @@ export default function QR() {
     const [nowPeople, setNowPeople] = useState(0);
     const [gameInfo, setGameInfo] = useAtom(gameAtoms);
     const [userInfo,] = useAtom(userInfoAtoms);
-    const gamePageUrl = `${process.env.NEXT_PUBLIC_RECRE_URL}/player?id=${userInfo.id}`;
     const [isLogin,] = useAtom(loginAtom);
     const router = useRouter();
     const [open, setOpen] = useState(true);
@@ -33,7 +32,8 @@ export default function QR() {
     const [token,] = useAtom(tokenAtoms);
     const [answer, setAnswer] = useAtom(answerAtom);
     const [uuId,] = useState<string>(uuidv4());
-    const socket = useRef(io(`${socketApi}?uuId=${uuId}`, {
+    const [nameSpace ,setNameSpace] = useState<string>('');
+    const socket = useRef(io(`${socketApi}/${nameSpace}?uuId=${uuId}`, {
         withCredentials: true,
         transports: ["websocket"],
         autoConnect: false,
@@ -49,12 +49,22 @@ export default function QR() {
         y: number;
         emotion: string;
     }
+    const gamePageUrl = `${process.env.NEXT_PUBLIC_RECRE_URL}/player?id=${userInfo.id}&game=${nameSpace}`;
 
     useEffect(() => {
         if (!isLogin) {
             // console.log(isLogin)
             alert('로그인이 필요합니다.')
             router.push("/")
+        }
+
+        switch (gameInfo[0]) {
+            case '그림 맞추기':
+                setNameSpace('catch')
+                break;
+            case '무궁화 꽃이 피었습니다':
+                setNameSpace('redgreen')
+                break;
         }
 
         socket.current.connect();
@@ -83,6 +93,11 @@ export default function QR() {
                 setOpen(false);
             else
                 alert(response.message)
+        });
+
+        socket.current.on("start_game", (response) => {
+            // console.log(response)
+            setOpen(false);
         });
 
         socket.current.on('set_catch_answer', (res)=>{
@@ -116,6 +131,8 @@ export default function QR() {
         const makeRoom = (acc_token: string) => {
             const game_t = JSON.parse(localStorage.getItem('game') || 'null');
             socket.current.emit('make_room', {
+                goalDistance : 100,
+                winnerNum : 3,
                 game_type: game_t[0],
                 user_num: game_t[1],
                 answer: answer,

--- a/app/gamePage/page.tsx
+++ b/app/gamePage/page.tsx
@@ -20,6 +20,7 @@ import Popover from '@mui/material/Popover';
 import { css, keyframes } from "@emotion/react";
 import React from 'react';
 import Flower from '../redGreen/page';
+import { redGreenInfoAtom } from '../modules/redGreenAtoms';
 
 export default function QR() {
     const [nowPeople, setNowPeople] = useState(0);
@@ -43,6 +44,7 @@ export default function QR() {
     const modalRef = useRef<HTMLDivElement | null>(null);
     const [emotions, setEmotions] = useState<emotion[]>([]);
     const popoverRef = useRef<HTMLDivElement | null>(null);
+    const [redGreenInfo, ] = useAtom(redGreenInfoAtom);
 
     interface emotion {
         x: number;
@@ -58,7 +60,7 @@ export default function QR() {
             router.push("/")
         }
 
-        switch (gameInfo[0]) {
+        switch (JSON.parse(localStorage.getItem('game') || 'null')[0]) {
             case '그림 맞추기':
                 setNameSpace('catch')
                 break;
@@ -131,8 +133,8 @@ export default function QR() {
         const makeRoom = (acc_token: string) => {
             const game_t = JSON.parse(localStorage.getItem('game') || 'null');
             socket.current.emit('make_room', {
-                goalDistance : 100,
-                winnerNum : 3,
+                goalDistance : redGreenInfo[1],
+                winnerNum : redGreenInfo[0],
                 game_type: game_t[0],
                 user_num: game_t[1],
                 answer: answer,

--- a/app/gamePage/page.tsx
+++ b/app/gamePage/page.tsx
@@ -49,7 +49,7 @@ export default function QR() {
         y: number;
         emotion: string;
     }
-    const gamePageUrl = `${process.env.NEXT_PUBLIC_RECRE_URL}/player?id=${userInfo.id}&game=${nameSpace}`;
+    const gamePageUrl = `${process.env.NEXT_PUBLIC_RECRE_URL}/player?data=${userInfo.id}_${nameSpace}`;
 
     useEffect(() => {
         if (!isLogin) {

--- a/app/gamePage/page.tsx
+++ b/app/gamePage/page.tsx
@@ -34,7 +34,7 @@ export default function QR() {
     const [answer, setAnswer] = useAtom(answerAtom);
     const [uuId,] = useState<string>(uuidv4());
     const [nameSpace ,setNameSpace] = useState<string>('');
-    const socket = useRef(io(`${socketApi}/${nameSpace}?uuId=${uuId}`, {
+    const socket = useRef(io(`${socketApi}/${JSON.parse(localStorage.getItem('game') || 'null')[0] === '그림 맞추기'?'catch':'redgreen'}?uuId=${uuId}`, {
         withCredentials: true,
         transports: ["websocket"],
         autoConnect: false,
@@ -68,7 +68,6 @@ export default function QR() {
                 setNameSpace('redgreen')
                 break;
         }
-
         socket.current.connect();
 
         socket.current.volatile.on("connect", () => {

--- a/app/gameSelect/page.tsx
+++ b/app/gameSelect/page.tsx
@@ -11,6 +11,13 @@ import { loginAtom } from "@/app/modules/loginAtoms";
 import { gameAtoms } from '../modules/gameAtoms';
 import { useRouter } from "next/navigation";
 import TextField from '@mui/material/TextField';
+import Radio from '@mui/material/Radio';
+import RadioGroup from '@mui/material/RadioGroup';
+import FormControlLabel from '@mui/material/FormControlLabel';
+import FormControl from '@mui/material/FormControl';
+import FormLabel from '@mui/material/FormLabel';
+import { InputLabel, MenuItem, Select } from '@mui/material';
+import { redGreenInfoAtom } from '../modules/redGreenAtoms';
 
 const Item = styled(Paper)(({ theme }) => ({
     backgroundColor: theme.palette.mode === 'dark' ? '#1A2027' : '#fff',
@@ -27,6 +34,7 @@ export default function GameSelect() {
     const router = useRouter();
     const [isHovering, setIsHovered] = useState(false);
     const [hoverElement, setHoverElement] = useState('');
+    const [redGreenInfo, setRedGreenInfo] = useAtom(redGreenInfoAtom);
 
     const onMouseEnter = (gameName: string) => {
         setIsHovered(true);
@@ -43,17 +51,32 @@ export default function GameSelect() {
     }, []);
 
     useEffect(() => {
+
         if (gameInfo[1] && gameInfo[1] > 0 && gameInfo[0]) {
             if (gameInfo[1] > 1000) {
                 alert('한 게임 당 참여가능한 인원은 1000명 이하입니다.')
                 setGameInfo([gameInfo[0], 0])
             }
-            else setIsReady(true);
+            else {
+                if(gameInfo[0] === '무궁화 꽃이 피었습니다'){
+                    if(redGreenInfo[0] && redGreenInfo[0] > 0){
+                        if(redGreenInfo[0] > gameInfo[1]){
+                            alert('우승자 수가 참여 인원보다 많습니다.')
+                            setRedGreenInfo([gameInfo[1],redGreenInfo[1]])
+                        }
+                        else{
+                            setIsReady(true);
+                        }
+                    }
+                    else setIsReady(false);
+                }
+                else setIsReady(true);
+            }
         }
         else {
             setIsReady(false);
         }
-    }, [gameInfo]);
+    }, [gameInfo, redGreenInfo]);
 
     const handleGameSelect = (game: string) => {
         if (gameInfo[0] === game) {
@@ -106,6 +129,7 @@ export default function GameSelect() {
             </div>
             <div className='gameInfoDiv'>
                 <div className='input_alert'>
+                    {(gameInfo[0] === '' || gameInfo[0] === null)?'':
                     <TextField
                         id="outlined-number"
                         label="인원 수"
@@ -116,7 +140,32 @@ export default function GameSelect() {
                         InputLabelProps={{
                             shrink: true,
                         }}
+                    />}{gameInfo[0] === '무궁화 꽃이 피었습니다'?<>
+                    <TextField
+                        id="outlined-number"
+                        label="우승자"
+                        placeholder='우승자 수를 입력해주세요'
+                        type="number"
+                        value={redGreenInfo[0]}
+                        onChange={(e) => setRedGreenInfo([parseInt(e.target.value),redGreenInfo[1]])}
+                        InputLabelProps={{
+                            shrink: true,
+                        }}
                     />
+                    <FormControl >
+  <InputLabel id="demo-simple-select-label">거리</InputLabel>
+  <Select
+    labelId="demo-simple-select-label"
+    id="demo-simple-select"
+    value={redGreenInfo[1]}
+    label="Age"
+    onChange={(e)=>setRedGreenInfo([redGreenInfo[0],parseInt(e.target.value as string)])}
+  >
+    <MenuItem value={50}>짧게</MenuItem>
+    <MenuItem value={100}>중간</MenuItem>
+    <MenuItem value={150}>길게</MenuItem>
+  </Select>
+</FormControl></>:''}
                 </div>
             </div>
             <Button variant='outlined' size="large" onClick={() => router.push("/gamePage")} disabled={!isReady}>{gameInfo[0] ? `${gameInfo[0]} 게임 시작하기` : '게임을 선택해주세요'}</Button>
@@ -192,7 +241,7 @@ export default function GameSelect() {
             .input_alert{
                 height: 100%;
                 display: flex;
-                flex-direction: column; 
+                flex-direction: row; 
                 align-items: center;
                 justify-content: space-evenly;
                 gap: 20px;

--- a/app/modules/redGreenAtoms.tsx
+++ b/app/modules/redGreenAtoms.tsx
@@ -1,0 +1,14 @@
+import { atom } from "jotai"
+import { atomWithStorage } from "jotai/utils"
+
+export const redGreenInfoAtom = atomWithStorage<number[]>('redGreenInfo',[3, 100]);
+
+export const setRedGreenInfo = atom(
+    null,
+    (get, set, newRedGreenInfo : number[]) => {
+        set(
+            redGreenInfoAtom,
+            newRedGreenInfo
+        )
+    }
+)

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -150,12 +150,11 @@ export default function Home() {
 
   return (<>
     <div className='container'>
-      <div>
+      {/* <div> */}
         <p className='middleLogo' onClick={selectGame}>시작하기</p>
-      </div>
-      {/* login시에만 보이는 버튼 */}
-      <div className="login">
-      </div>
+        <div className="sketchfab-embed-wrapper"> <iframe title="GAME ROOM | Pixel Art" frameBorder="0" allowFullScreen allow="autoplay, fullscreen, xr-spatial-tracking" xr-spatial-tracking execution-while-out-of-viewport execution-while-not-rendered web-share src="https://sketchfab.com/models/d02c6808cbd34259be5ae86650afef1b/embed?autostart=1"> </iframe> <p style={{fontSize: '13px', fontWeight: 'normal', margin: '5px', color: '#4A4A4A'}}> </p></div>
+        
+      {/* </div> */}
     </div>
     <style jsx>{`
             .container{

--- a/app/player/page.tsx
+++ b/app/player/page.tsx
@@ -44,10 +44,10 @@ export default function Player() {
         if(data[1]){
             switch (data[1]) {
                 case 'catch':
-                    setGameContent(<RedGreenPlayer roomId={data[0] as string} socket={socket.current}/>)
+                    setGameContent(<CatchPlayer roomId={data[0] as string} socket={socket.current} />)
                     break;
                 case 'redgreen':
-                    setGameContent(<CatchPlayer roomId={data[0] as string} socket={socket.current} />)
+                    setGameContent(<RedGreenPlayer roomId={data[0] as string} socket={socket.current}/>)
                     break;
             }
         }

--- a/app/player/page.tsx
+++ b/app/player/page.tsx
@@ -19,8 +19,7 @@ import { type } from 'os';
 
 export default function Player() {
     const params = useSearchParams();
-    const room_id = params.get('id');
-    const namespace = params.get('nameSpace');
+    const [data, setData] = useState<string[]>(params.get('data')?.split('_') ?? []);
     const router = useRouter();
     //query string에서 hostId를 가져옴
     const [playerNickname, setPlayerNickname] = useState<string | null>(null);
@@ -28,17 +27,19 @@ export default function Player() {
     const [isGame, setIsGame] = useState<boolean>(false);
     const [uuId,] = useState<string>(uuidv4());
     const vh = useVH();
-    const socket = useRef(io(`${socketApi}/${namespace}?uuId=${uuId}`, {
+    const socket = useRef(io(`${socketApi}/${data[1]}?uuId=${uuId}`, {
         withCredentials: true,
         transports: ["websocket"],
         autoConnect: false,
     }));
 
     useEffect(() => {
-        if (room_id === null) {
+        if (data[0] === null) {
             alert('잘못된 접근입니다.');
             router.push("/");
         }
+
+
 
         socket.current.on("start_catch_game", (res) => {
             if (res.result === true) {
@@ -90,7 +91,7 @@ export default function Player() {
         }
         socket.current.connect();
         socket.current.emit("ready", {
-            room_id: room_id,
+            room_id: data[0],
             nickname: playerNickname
         });
     };
@@ -103,7 +104,7 @@ export default function Player() {
 
     const expressEmotion = (emotion: string) => {
         socket.current.emit("express_emotion", {
-            room_id: room_id,
+            room_id: data[0],
             emotion: emotion
         });
     }
@@ -114,7 +115,7 @@ export default function Player() {
     return (
         <>{isGame ?
             //캐치마인드 게임이 시작되면 catch로 이동
-            <CatchPlayer roomId={room_id as string} socket={socket.current} /> :
+            <CatchPlayer roomId={data[0] as string} socket={socket.current} /> :
             //무궁화꽃이피었습니다 게임이 시작되면 flower로 이동
             <>
                 <div className="nickname-container">

--- a/app/player/page.tsx
+++ b/app/player/page.tsx
@@ -116,7 +116,7 @@ export default function Player() {
 
 
     return (
-        <>{isGame ? data[1] === 'redgreen'?<RedGreenPlayer/>:
+        <>{isGame ? data[1] === 'redgreen'?<RedGreenPlayer roomId={data[0] as string} socket={socket.current}/>:
             //캐치마인드 게임이 시작되면 catch로 이동
             <CatchPlayer roomId={data[0] as string} socket={socket.current} /> :
             //무궁화꽃이피었습니다 게임이 시작되면 flower로 이동

--- a/app/player/page.tsx
+++ b/app/player/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 import Button from '@mui/material/Button';
 import { useSearchParams, useRouter } from "next/navigation";
-import { useEffect, useRef } from "react";
+import React, { useEffect, useRef } from "react";
 import { useState } from "react";
 import CatchPlayer from '../playerComponent/catchPlayer';
 import { io } from "socket.io-client";
@@ -33,6 +33,7 @@ export default function Player() {
         transports: ["websocket"],
         autoConnect: false,
     }));
+    const [gameContent, setGameContent] = useState<JSX.Element | null>(null);
 
     useEffect(() => {
         if (parseInt(data[0]) === null) {
@@ -40,7 +41,20 @@ export default function Player() {
             router.push("/");
         }
 
-
+        if(data[1]){
+            switch (data[1]) {
+                case 'catch':
+                    setGameContent(<RedGreenPlayer roomId={data[0] as string} socket={socket.current}/>)
+                    break;
+                case 'redgreen':
+                    setGameContent(<CatchPlayer roomId={data[0] as string} socket={socket.current} />)
+                    break;
+            }
+        }
+        else{
+            alert('잘못된 접근입니다.');
+            router.push("/");
+        }
 
         socket.current.on("start_catch_game", (res) => {
             if (res.result === true) {
@@ -72,7 +86,6 @@ export default function Player() {
         })
 
         socket.current.on("ready", (res) => {
-            alert(32323)
             if (res.result === true) {
                 // alert('ready')
                 setReady(true)
@@ -96,7 +109,6 @@ export default function Player() {
     }, []);
 
     const readyToPlay = () => {
-        alert(`${parseInt(data[0])}, ${data[1]}`)
         if (playerNickname === null || playerNickname === '') {
             alert('닉네임을 입력해주세요.')
             return
@@ -125,9 +137,7 @@ export default function Player() {
 
 
     return (
-        <>{isGame ? data[1] === 'redgreen'?<RedGreenPlayer roomId={data[0] as string} socket={socket.current}/>:
-            //캐치마인드 게임이 시작되면 catch로 이동
-            <CatchPlayer roomId={data[0] as string} socket={socket.current} /> :
+        <>{isGame ? gameContent :
             //무궁화꽃이피었습니다 게임이 시작되면 flower로 이동
             <>
                 <div className="nickname-container">

--- a/app/player/page.tsx
+++ b/app/player/page.tsx
@@ -34,7 +34,7 @@ export default function Player() {
     }));
 
     useEffect(() => {
-        if (data[0] === null) {
+        if (parseInt(data[0]) === null) {
             alert('잘못된 접근입니다.');
             router.push("/");
         }
@@ -91,7 +91,7 @@ export default function Player() {
         }
         socket.current.connect();
         socket.current.emit("ready", {
-            room_id: data[0],
+            room_id: parseInt(data[0]),
             nickname: playerNickname
         });
     };
@@ -104,7 +104,7 @@ export default function Player() {
 
     const expressEmotion = (emotion: string) => {
         socket.current.emit("express_emotion", {
-            room_id: data[0],
+            room_id: parseInt(data[0]),
             emotion: emotion
         });
     }

--- a/app/player/page.tsx
+++ b/app/player/page.tsx
@@ -50,6 +50,15 @@ export default function Player() {
             }
         })
 
+        socket.current.on("start_game", (res) => {
+            if (res.result === true) {
+                setIsGame(true)
+            } else {
+                alert(res.message)
+            }
+        })
+
+
         socket.current.on("end", (res) => {
             if (res.result === true) {
                 alert('게임이 종료되었습니다.')

--- a/app/player/page.tsx
+++ b/app/player/page.tsx
@@ -62,6 +62,7 @@ export default function Player() {
         })
 
         socket.current.on("ready", (res) => {
+            alert(32323)
             if (res.result === true) {
                 // alert('ready')
                 setReady(true)
@@ -85,6 +86,7 @@ export default function Player() {
     }, []);
 
     const readyToPlay = () => {
+        alert(`${parseInt(data[0])}, ${data[1]}`)
         if (playerNickname === null || playerNickname === '') {
             alert('닉네임을 입력해주세요.')
             return

--- a/app/player/page.tsx
+++ b/app/player/page.tsx
@@ -12,7 +12,7 @@ import { Alert, Box, ButtonGroup } from '@mui/material';
 import { isMobile, browserName } from 'react-device-detect';
 import Image from 'next/image';
 import { type } from 'os';
-import RedGreenPlayer from '../redgreentemp/page';
+import RedGreenPlayer from '../playerComponent/redGreenPlayer';
 
 
 

--- a/app/player/page.tsx
+++ b/app/player/page.tsx
@@ -20,6 +20,7 @@ import { type } from 'os';
 export default function Player() {
     const params = useSearchParams();
     const room_id = params.get('id');
+    const namespace = params.get('nameSpace');
     const router = useRouter();
     //query string에서 hostId를 가져옴
     const [playerNickname, setPlayerNickname] = useState<string | null>(null);
@@ -27,7 +28,7 @@ export default function Player() {
     const [isGame, setIsGame] = useState<boolean>(false);
     const [uuId,] = useState<string>(uuidv4());
     const vh = useVH();
-    const socket = useRef(io(`${socketApi}?uuId=${uuId}`, {
+    const socket = useRef(io(`${socketApi}/${namespace}?uuId=${uuId}`, {
         withCredentials: true,
         transports: ["websocket"],
         autoConnect: false,
@@ -218,7 +219,7 @@ export default function Player() {
                     justify-content: center;
                     background-color: #F5F5F5;
                 }
-                .alertDiv{
+                .alertDiv{ 
                     width: 70%;
                     display: flex;
                     justify-content: center;

--- a/app/player/page.tsx
+++ b/app/player/page.tsx
@@ -12,6 +12,7 @@ import { Alert, Box, ButtonGroup } from '@mui/material';
 import { isMobile, browserName } from 'react-device-detect';
 import Image from 'next/image';
 import { type } from 'os';
+import RedGreenPlayer from '../redgreentemp/page';
 
 
 
@@ -115,7 +116,7 @@ export default function Player() {
 
 
     return (
-        <>{isGame ?
+        <>{isGame ? data[1] === 'redgreen'?<RedGreenPlayer/>:
             //캐치마인드 게임이 시작되면 catch로 이동
             <CatchPlayer roomId={data[0] as string} socket={socket.current} /> :
             //무궁화꽃이피었습니다 게임이 시작되면 flower로 이동

--- a/app/playerComponent/redGreenPlayer.tsx
+++ b/app/playerComponent/redGreenPlayer.tsx
@@ -80,28 +80,29 @@ export default function RedGreenPlayer({ roomId, socket }: { roomId: string, soc
         };
     }
 
-    // //통과
-    // socket.current.on('touchdown', (res) => {
-    //     alert(`이겼습니다. 우승자는 ${res.name}입니다.
-    //         이동거리: ${res.distance}, 걸린 시간: ${res.endtime}`);
-    //     //이겼을 때 화면에 표시되어야 할 것들
-    // });
+    useEffect(() => {
+        //통과
+        socket.on('touchdown', (res) => {
+            alert(`이겼습니다. 우승자는 ${res.name}입니다.
+                이동거리: ${res.distance}, 걸린 시간: ${res.endtime}`);
+            //이겼을 때 화면에 표시되어야 할 것들
+        });
+    
+        //죽음
+        socket.on('youdie', (res)=> {
+            setIsAlive(false);
+            alert(`죽었습니다. ${res.name}는 ${res.endtime}만큼 생존했습니다.`);
+            //기타 죽었을 때 화면에 표시되어야 할 것들
+        })
+    },[])
 
-    // //죽음
-    // socket.current.on('youdie', (res)=> {
-    //     setIsAlive(false);
-    //     alert(`죽었습니다. ${res.name}는 ${res.endtime}만큼 생존했습니다.`);
-    //     //기타 죽었을 때 화면에 표시되어야 할 것들
-    // })
-
-    // //달리는 중
-    // useEffect(() => {
-    //     if (isAlive) {
-    //         socket.current.emit('run', {
-    //             roomId: roomId,
-    //             shakeCount: shakeCount,});
-    //     }
-    // }, [shakeCount]);
+    //달리는 중
+    useEffect(() => {
+        if (isAlive) {
+            socket.emit('run', {
+                shakeCount: shakeCount,});
+        }
+    }, [shakeCount]);
 
     return (
         <div>

--- a/app/playerComponent/redGreenPlayer.tsx
+++ b/app/playerComponent/redGreenPlayer.tsx
@@ -106,6 +106,7 @@ export default function RedGreenPlayer({ roomId, socket }: { roomId: string, soc
     return (
         <div>
             <button onClick={requestPermissionSafari}>허가</button>
+            <button onClick={()=>setShakeCount((prev)=>prev+1)}>허가</button>
             <p>Shake Count: {shakeCount};</p>
         </div>
     );

--- a/app/redGreen/page.tsx
+++ b/app/redGreen/page.tsx
@@ -18,17 +18,24 @@ export default function RedGreen({socket}: {socket : Socket}) {
       score: 1,
     }]);
     const [isFinished, setIsFinished] = useState(false);
+
+    enum state {
+      alive = 'ALIVE',
+      dead = 'DEAD',
+      finish = 'FINISH',
+    }
+
     const [playerInfo, setPlayerInfo] = useState<playerInfo[]>([{
       nickname: '',
       distance: 0,
-      isAlive: true,
+      state: state.alive,
     }]);
     const [go,setGo] = useState(false);
 
     interface playerInfo {
         nickname: string,
         distance: number,
-        isAlive : boolean,
+        state : state,
     }
 
     interface winnerInfo { 
@@ -38,7 +45,11 @@ export default function RedGreen({socket}: {socket : Socket}) {
 
     useEffect(() => {
         socket.on('players_status', (res) => {
-            setPlayerInfo(res.playerInfo.filter((player: playerInfo) => player.isAlive === true));
+
+          console.log(res.player_info)
+          if(res.player_info){
+            setPlayerInfo(res.player_info.filter((player: playerInfo) => player.state === state.alive));
+          }
         });
 
 

--- a/app/redgreentemp/page.tsx
+++ b/app/redgreentemp/page.tsx
@@ -1,112 +1,120 @@
 "use client";
-import { useState, useRef, useEffect } from 'react';
+import { useEffect, useState, useRef } from 'react';
 import { Socket } from "socket.io-client";
 import { io } from "socket.io-client";
 import { socketApi } from '../modules/socketApi';
 
-let accelerationData: number[] = [];
-let lastAcceleration = 0;
-
-export default function RedGreenPlayer({ roomId, socket }: { roomId: string, socket: Socket }) {
+export default function RedGreenPlayer({ roomId,  }: { roomId: string, socket: Socket }) {
     const [shakeCount, setShakeCount] = useState(0);
     const [isAlive, setIsAlive] = useState(true); //생존 여부를 관리하는 상태
+    const [yCount, setYCount] = useState(0);
+    // const [minY, setMinY] = useState(0);
+    // const [maxY, setMaxY] = useState(0);
+    // const [wasYBelowThreshold, setWasYBelowThreshold] = useState<boolean>(true);
+    // const [text,setText] = useState<string>(''); //텍스트 입력창에 입력된 텍스트를 관리하는 상태
     //test를 위한 임시 socket 설정
-    // const socket = useRef(io(`${socketApi}?uuId=123`, {
-    //     withCredentials: true,
-    //     transports: ["websocket"],
-    //     autoConnect: false,
-    // }));
-    
-    //shake 이벤트가 발생하면 shakeCount를 1 증가시키는 함수
-    const handleShake = () => {
-        if (isAlive) {
-            setShakeCount((prevCount) => prevCount + 1);
-        }
-    }
+    const socket = useRef(io(`${socketApi}?uuId=123`, {
+        withCredentials: true,
+        transports: ["websocket"],
+        autoConnect: false,
+    }));
 
-    //device의 움직임을 읽어오는 함수
-    const handleDeviceMotion = (event: DeviceMotionEvent) => {
-        const acceleration= event.acceleration;
 
-        if (acceleration) {
-            const accelerationMagnitude = (acceleration.y??0)
-            const smoothedAcceleration = 0.2 * accelerationMagnitude + 0.8 * lastAcceleration;
-            lastAcceleration = smoothedAcceleration;
-            accelerationData.push(smoothedAcceleration);
-
-            const maxDataLength = 3;
-            if (accelerationData.length > maxDataLength) {
-                accelerationData = accelerationData.slice(1);
-            }
-
-            const peakIndex = detectPeak(accelerationData);
-
-            if (peakIndex !== -1) {
-                handleShake();
-            }
-        }
-    };
-
-    const detectPeak = (data: number[]): number => {
-        const threshold = 1.5; // Adjust this threshold based on testing
-    
-        for (let i = 1; i < data.length - 1; i++) {
-          if (data[i] > data[i - 1] && data[i] > data[i + 1] && data[i] > threshold) {
-            return i;
-          }
-        }
-        return -1;
-      };
-
-    //iOS 13 이상의 safari 브라우저에서는 모션 이벤트 권한을 요청해야 함
+        //safari 13 이상의 safari 브라우저에서는 모션 이벤트 권한을 요청해야 함
     const isSafariOver13 = typeof window.DeviceOrientationEvent.requestPermission === 'function';
 
     const requestPermissionSafari = () => {
-        //iOS
         if (isSafariOver13) {
             window.DeviceOrientationEvent.requestPermission().then((permissionState) => {
                 if (permissionState === 'denied') {
                     //safari 브라우저를 종료하고 다시 접속하도록 안내하는 화면 필요
                     alert('게임에 참여 하려면 센서 권한을 허용해주세요. Safari를 완전히 종료하고 다시 접속해주세요.');
                     return;
-                } else if (permissionState === 'granted') {
-                    window.addEventListener('devicemotion', handleDeviceMotion);
-                };
-            })
+                // } else if (permissionState === 'granted') {
+                //     window.addEventListener('devicemotion', handleDeviceMotion);
+                }
+            });
+        }          
+    };
 
-        //android         
-        } else {
-            window.addEventListener('devicemotion', handleDeviceMotion);
-        };
-    }
+    let stepCount = 0;
+    let accelerationData:any = [];
+    let lastAcceleration = 0;
 
-    // //통과
-    // socket.current.on('touchdown', (res) => {
-    //     alert(`이겼습니다. 우승자는 ${res.name}입니다.
-    //         이동거리: ${res.distance}, 걸린 시간: ${res.endtime}`);
-    //     //이겼을 때 화면에 표시되어야 할 것들
-    // });
+        // Check if the DeviceMotion API is supported
+    window.addEventListener('devicemotion', handleDeviceMotion);
 
-    // //죽음
-    // socket.current.on('youdie', (res)=> {
-    //     setIsAlive(false);
-    //     alert(`죽었습니다. ${res.name}는 ${res.endtime}만큼 생존했습니다.`);
-    //     //기타 죽었을 때 화면에 표시되어야 할 것들
-    // })
+    function handleMotion(event) {
+        // The acceleration data is available in the x, y, and z properties of the event
+        const acceleration = event.acceleration;
 
-    // //달리는 중
-    // useEffect(() => {
-    //     if (isAlive) {
-    //         socket.current.emit('run', {
-    //             roomId: roomId,
-    //             shakeCount: shakeCount,});
-    //     }
-    // }, [shakeCount]);
+        // Calculate the magnitude of acceleration
+        const accelerationMagnitude = Math.sqrt(acceleration.x ** 2 + acceleration.y ** 2 + acceleration.z ** 2);
+
+        // Smooth the acceleration data using a simple low-pass filter
+        const smoothedAcceleration = 0.2 * accelerationMagnitude + 0.8 * lastAcceleration;
+
+        // Update the lastAcceleration for the next iteration
+        lastAcceleration = smoothedAcceleration;
+
+        // Add the smoothed acceleration to the data array
+        accelerationData.push(smoothedAcceleration);
+
+        // Keep only the last N samples to avoid memory overflow
+        const maxDataLength = 10;
+        if (accelerationData.length > maxDataLength) {
+            accelerationData = accelerationData.slice(1);
+        }
+
+            // Detect peaks in the acceleration data
+            const peakIndex = detectPeak(accelerationData);
+
+            // If a peak is detected, increment the step count
+            if (peakIndex !== -1) {
+                stepCount++;
+                updateStepCount();
+            }
+        }
+
+        function updateStepCount() {
+            document.getElementById('stepCount').innerText = stepCount;
+        }
+
+        // Simple peak detection algorithm
+        function detectPeak(data) {
+            const threshold = 1.5; // Adjust this threshold based on testing
+
+            for (let i = 1; i < data.length - 1; i++) {
+                if (data[i] > data[i - 1] && data[i] > data[i + 1] && data[i] > threshold) {
+                    return i;
+                }
+            }
+
+            return -1;
+        }
+
+
+
+    socket.current.on('touchdown', (res) => {
+        alert(`이겼습니다. 우승자는 ${res.name}입니다.
+            이동거리: ${res.distance}, 걸린 시간: ${res.endtime}`);
+        //이겼을 때 화면에 표시되어야 할 것들
+    });
+
+    socket.current.on('youdie', (res)=> {
+        setIsAlive(false);
+        alert(`죽었습니다. ${res.name}는 ${res.endtime}만큼 생존했습니다.`);
+        //기타 죽었을 때 화면에 표시되어야 할 것들
+    })
 
     return (
         <div>
             <button onClick={requestPermissionSafari}>허가</button>
             <p>Shake Count: {shakeCount};</p>
+            {/* <p>y: {yCount}</p> */}
+            {/* <p>y: {maxY}</p>
+            <p>y: {minY}</p> */}
+
         </div>
     );
 }


### PR DESCRIPTION
# 1. gameSelect 페이지에서 무궁화 게임 선택시 옵션 설정 기능 추가

* 무궁화 게임 선택시 기존 인원수에 이어 우승자 수, 거리 옵션을 추가함. 
* 선택된 옵션은 redGreenAtoms 에 저장되어 gamePages에서 사용됨

close #103

# 2. QR 페이지에서 room 생성이 안되는 문제 임시 해결

### 문제 원인
게임 종류에 따라 socket의 url 이 나뉘는데 게임 종류가 담긴 atom을 가져오지 못함. 

### 해결 시도 1
* 로컬 스토리지에서 바로 게임 종류를 가져와서 게임종류를 담는 useState 변수에 set을 해준 후, 그 변수를 SOCKET으로 주었다.
* 하지만 그럼에도 불구하고 게임 종류 정보를 가져오지 못 했다.

### 해결 시도 2
* 때문에 socket의 url에 localstorage에서 바로 갖고와서 삼항연산자로 다이렉트로 집어넣었다.
* 성공하기는 했지만 재사용성이 떨어지므로 나중에 수정이 필요하다. issue에 남겨놓음

close #106

3. # playerPage 에서 playerComponent/redgreenPlayer 를 불러오게 하기

인자로 들어온 게임 종류에 따라 useEffect로 페이지가 로딩되면 해당 게임 컴포넌트를 gameContent에 set 하게 해놓음

close #85
