### PR TITLE
Player page fix

### DIFF
--- a/app/playerComponent/catchPlayer.tsx
+++ b/app/playerComponent/catchPlayer.tsx
@@ -2,6 +2,7 @@ import { Button, InputAdornment, TextField } from "@mui/material";
 import { useState } from "react";
 import { Socket } from "socket.io-client";
 import { useEffect, useRef } from 'react';
+import MyModal from '@/component/MyModal';
 
 export default function CatchPlayer({ roomId, socket }: { roomId: string, socket: Socket }) {
     const [playerAnswer, setPlayerAnswer] = useState<string>('');

--- a/app/playerComponent/redGreenPlayer.tsx
+++ b/app/playerComponent/redGreenPlayer.tsx
@@ -7,6 +7,7 @@ import { socketApi } from '../modules/socketApi';
 import MyModal from '@/component/MyModal';
 import List from '@mui/material/List';
 import ListItem from '@mui/material/ListItem';
+import Image from 'next/image';
 
 let accelerationData: number[] = [];
 let lastAcceleration = 0;
@@ -27,6 +28,8 @@ export default function RedGreenPlayer({ roomId, socket, length, win_num, total_
     const outlineClassName = isGreen ? 'outline-player-page-green' : 'outline-player-page-red';
     //생존 여부에 따라 minimap 색깔을 바꿔주는 클래스 이름을 동적으로 결정
     const minimapClassName = isAlive ? 'minimap-player' : 'minimap-player-dead';
+    //왼쪽에서 오른쪽으로 얼마나 진행했는지를 계산
+    let progress = 0;
 
     //시간 측정 함수
     const timeCheck = (startTime: Date, endTime: Date):string | void => {
@@ -160,6 +163,7 @@ export default function RedGreenPlayer({ roomId, socket, length, win_num, total_
             socket.emit('run', {
                 shakeCount: shakeCount,});
         }
+        progress = (shakeCount / length) * 100;
     }, [shakeCount]);
 
     return (
@@ -172,15 +176,17 @@ export default function RedGreenPlayer({ roomId, socket, length, win_num, total_
                 <button onClick={()=>setShakeCount((prev)=>prev+1)}>test</button>
             </div>
             <div className={minimapClassName}>
-                
+                <div className="icon">
+                    <Image src="/walker.png" alt="walker" width={50} height={50} />
+                </div>
             </div>
           <MyModal open={open} modalHeader={modalHeader} modalContent={modalContent} closeFunc={() => { }} myref={null}/>
         </div>
         <style jsx>{`
             .outline-player-page-green {
                 margin: 20px auto;
-                padding: 10px auto;
-                outline: 20px solid green;
+                /* padding: 10px auto; */
+                outline: 30px solid green;
                 display: flex;
                 flex-direction: column;
                 justify-content: space-evenly;
@@ -191,8 +197,8 @@ export default function RedGreenPlayer({ roomId, socket, length, win_num, total_
             }
             .outline-player-page-red {
                 margin: 20px auto;
-                padding: 10px auto;
-                outline: 20px solid red;
+                /* padding: 10px auto; */
+                outline: 30px solid red;
                 display: flex;
                 flex-direction: column;
                 justify-content: space-evenly;
@@ -202,18 +208,17 @@ export default function RedGreenPlayer({ roomId, socket, length, win_num, total_
                 width: 80vw      
             }
             .speech-bubble-player {
-                margin: 20px auto;
+                margin: 30px auto;
                 width: 100%;
                 height: 50%;
                 display: flex;
                 flex: 1;
                 flex-direction: column;
-                outline: 10px solid black;
+                outline: 20px solid black;
                 justify-content: space-evenly;
                 align-items: center;
             }
             .minimap-player {
-                margin: 20px auto;
                 width: 100%;
                 height: 50%;
                 display: flex;
@@ -221,11 +226,10 @@ export default function RedGreenPlayer({ roomId, socket, length, win_num, total_
                 flex-direction: column;
                 justify-content: space-evenly;
                 align-items: center;
-                border-bottom: 5px solid purple;
+                border-bottom: 5px solid #5C4033;
 
             }
             .minimap-player-dead {
-                margin: 20px auto;
                 width: 50%;
                 height: 100%;
                 display: flex;
@@ -235,6 +239,11 @@ export default function RedGreenPlayer({ roomId, socket, length, win_num, total_
                 align-items: center;
                 background-color: gray;
                 border-bottom: 5px solid gray;
+            }
+            .icon {
+                width: 50%;
+                height: 50%;
+                left: ${progress}%;
             }
         `}</style>
         <style jsx global>{`

--- a/app/playerComponent/redGreenPlayer.tsx
+++ b/app/playerComponent/redGreenPlayer.tsx
@@ -22,6 +22,7 @@ export default function RedGreenPlayer({ roomId, socket, length, win_num, total_
     const [myrank, setMyRank] = useState<number>(0); //등수를 관리하는 상태
     const [nickname, setNickname] = useState<string>('');
     const [isGreen, setIsGreen] = useState<boolean>(true); //초록색인지 빨간색인지를 관리하는 상태
+    const [progress, setProgress] = useState<number>(0); //왼쪽에서 오른쪽으로 얼마나 진행했는지를 관리하는 상태
     const vh = useVH();
 
     //초록색인지 빨간색인지에 따라 outline 색깔을 바꿔주는 클래스 이름을 동적으로 결정
@@ -29,7 +30,6 @@ export default function RedGreenPlayer({ roomId, socket, length, win_num, total_
     //생존 여부에 따라 minimap 색깔을 바꿔주는 클래스 이름을 동적으로 결정
     const minimapClassName = isAlive ? 'minimap-player' : 'minimap-player-dead';
     //왼쪽에서 오른쪽으로 얼마나 진행했는지를 계산
-    let progress = 0;
 
     //시간 측정 함수
     const timeCheck = (startTime: Date, endTime: Date):string | void => {
@@ -162,8 +162,8 @@ export default function RedGreenPlayer({ roomId, socket, length, win_num, total_
         if (isAlive) {
             socket.emit('run', {
                 shakeCount: shakeCount,});
+            setProgress((shakeCount / length) * 100);    
         }
-        progress = (shakeCount / length) * 100;
     }, [shakeCount]);
 
     return (
@@ -176,8 +176,8 @@ export default function RedGreenPlayer({ roomId, socket, length, win_num, total_
                 <button onClick={()=>setShakeCount((prev)=>prev+1)}>test</button>
             </div>
             <div className={minimapClassName}>
-                <div className="icon">
-                    <Image src="/walker.png" alt="walker" width={50} height={50} />
+                <div className="icon" style={{left: `${progress}%`}}>
+                    <Image src="/walker.png" alt="walker" width={100} height={100} />
                 </div>
             </div>
           <MyModal open={open} modalHeader={modalHeader} modalContent={modalContent} closeFunc={() => { }} myref={null}/>
@@ -208,19 +208,18 @@ export default function RedGreenPlayer({ roomId, socket, length, win_num, total_
                 width: 80vw      
             }
             .speech-bubble-player {
-                margin: 30px auto;
                 width: 100%;
                 height: 50%;
                 display: flex;
                 flex: 1;
                 flex-direction: column;
-                outline: 20px solid black;
+                border-bottom: 20px solid black;
                 justify-content: space-evenly;
                 align-items: center;
             }
             .minimap-player {
                 width: 100%;
-                height: 50%;
+                height: 100%;
                 display: flex;
                 flex: 1;
                 flex-direction: column;
@@ -230,7 +229,7 @@ export default function RedGreenPlayer({ roomId, socket, length, win_num, total_
 
             }
             .minimap-player-dead {
-                width: 50%;
+                width: 100%;
                 height: 100%;
                 display: flex;
                 flex: 1;
@@ -241,9 +240,10 @@ export default function RedGreenPlayer({ roomId, socket, length, win_num, total_
                 border-bottom: 5px solid gray;
             }
             .icon {
-                width: 50%;
-                height: 50%;
-                left: ${progress}%;
+                position: absolute;
+                margin-right: 30%;
+                bottom: 0;
+                transition: left 0.3s ease;
             }
         `}</style>
         <style jsx global>{`


### PR DESCRIPTION
close #130 

실시간으로 red, green 을 받으면 테두리 역시 같은 색깔로 변경. 구현

touchdown 을 on 했을 때(통과했을 때) 테두리를 파란색으로 변경. ?

죽었을 경우 배경색을 회색(아마도)으로 변경. 구현

화면 위쪽 절반 크기를 말풍선으로 채우고, 그 말풍선 안에 나의 실시간 거리, 나의 실시간 등수를 표시. 구현

통과했을 경우에는 나의 등수와 시간을 표시. 좀 이상함

화면 아래 절반에는 간단한 횡스크롤 2차원 맵으로 현재 내 캐릭터가 얼마나 진행했냐를 표시. 구현