### PR TITLE
Add latency measurement and send it with each run

### DIFF
--- a/app/playerComponent/redGreenPlayer.tsx
+++ b/app/playerComponent/redGreenPlayer.tsx
@@ -153,22 +153,6 @@ export default function RedGreenPlayer({ roomId, socket, length, win_num, total_
             setMyRank(res.rank);
         });
 
-        socket.on("ping", (res: { server_ts: number }, callback) => {
-          /**
-           * 1. server -> player "ping": server_ts
-           * 2. player -> server "ping ack": server_ts, client_ts
-           * 3. server -> player "pong": server_ts, client_ts, server_ack_ts
-           */
-          if (!res) {
-            console.error("💀 res not found!!");
-            return;
-          }
-
-          const { server_ts } = res;
-          const client_ts = performance.now();
-          callback({ server_ts, client_ts });
-        });
-
         setInterval(() => {
           const start = performance.now();
           socket.emit("ping", {start}, (res: {start: number}) => {

--- a/app/playerComponent/redGreenPlayer.tsx
+++ b/app/playerComponent/redGreenPlayer.tsx
@@ -169,19 +169,15 @@ export default function RedGreenPlayer({ roomId, socket, length, win_num, total_
           callback({ server_ts, client_ts });
         });
 
-        socket.on("pong", (res: { server_ts: number; client_ts: number, server_ack_ts: number }) => {
-            if (!res) {
-                console.error("💀 res not found!!");
-                return;
-            }
-            const { server_ts: serverTs, client_ts: clientTs, server_ack_ts: serverAckTs } = res;
-            const clientAckTs = performance.now();
-            const serverRoundTripTime = serverAckTs - serverTs;
-            const clientRoundTripTime = (clientAckTs - clientTs) / 2;
-            const latency = serverRoundTripTime - clientRoundTripTime;
-            console.debug(`나의 지연시간: ${latency}ms`);
+        setInterval(() => {
+          const start = performance.now();
+          socket.emit("ping", {start}, (res: {start: number}) => {
+            const end = performance.now();
+            const latency = (end - res.start) / 2;
             setLatency(latency);
-        });
+            console.log(`latency: ${latency}ms`);
+          });
+        }, 2000);
         
         return () => {
             localStorage.removeItem('nickname')


### PR DESCRIPTION
이 풀 리퀘스트는 지연 시간을 측정하는 기능을 추가하여 각 실행과 함께 전송합니다. 지연 시간은 서버에 핑을 보내고 왕복 시간을 측정하여 계산됩니다. 그런 다음 평균 지연 시간이 밀리초 단위로 표시됩니다. 이 기능은 애플리케이션의 성능을 모니터링하고 잠재적인 지연을 식별하는 데 도움이 됩니다.