### PR TITLE
feat: add vibration when player ready (in android)

### DIFF
--- a/app/player/page.tsx
+++ b/app/player/page.tsx
@@ -236,6 +236,10 @@ export default function Player() {
                     room_id: parseInt(data[0]),
                     nickname: playerNickname,
                 });
+                let isSafari = /^((?!chrome|android).)*safari/i.test(navigator.userAgent);
+                if (!isSafari) {
+                    navigator.vibrate([1000,500,1000]);
+                }
             }
         }
     }, [shakeCount])


### PR DESCRIPTION
close #62 

안드로이드 사용자 한정으로 흔들어서 ready 를 수행하면 2번 진동이 오는 기능을 추가했습니다.

safari는 해당 method를 지원하지 않아서 안됩니다. 병신 브라우저