### PR TITLE
add vibration and delete DEAD player's rank at modal

### DIFF
--- a/app/player/page.tsx
+++ b/app/player/page.tsx
@@ -236,6 +236,10 @@ export default function Player() {
                     room_id: parseInt(data[0]),
                     nickname: playerNickname,
                 });
+                let isSafari = /^((?!chrome|android).)*safari/i.test(navigator.userAgent);
+                if (!isSafari) {
+                    navigator.vibrate([1000,500,1000]);
+                }
             }
         }
     }, [shakeCount])

--- a/app/playerComponent/redGreenPlayer.tsx
+++ b/app/playerComponent/redGreenPlayer.tsx
@@ -135,7 +135,7 @@ export default function RedGreenPlayer({ roomId, socket, length, win_num, total_
             const elapsedTime = timeCheck(new Date(res.elapsed_time)); //게임 시간 계산
             setIsAlive(false);
             setModalHeader('죽었습니다!');
-            setModalContent(<div>{res.name}님께서는 탈락하셨습니다!<br></br> 이동 거리: {res.distance>length?length:res.distance} / {length}<br></br> 생존 시간 : {elapsedTime} <br></br> 등수 : {myrank} / {total_num}</div> );
+            setModalContent(<div>{res.name}님께서는 탈락하셨습니다!<br></br> 이동 거리: {res.distance>length?length:res.distance} / {length}<br></br> 생존 시간 : {elapsedTime} </div> );
             setOpen(true);
             //기타 죽었을 때 화면에 표시되어야 할 것들
         });


### PR DESCRIPTION
close #62 

안드로이드 사용자 한정으로 흔들어서 ready 를 수행하면 2번 진동이 오는 기능을 추가했습니다.

safari는 해당 method를 지원하지 않아서 안됩니다. 병신 브라우저

close #135 

메인 화면에서 죽은 사람의 순위도 실시간으로 올라가는게 보여서 모달창에서는 빼버렸습니다.