### PR TITLE
Add touchdown line to the scene

### DIFF
--- a/component/youngHee.tsx
+++ b/component/youngHee.tsx
@@ -245,7 +245,7 @@ const YoungHee = ({
       opacity: 0.5,
     });
     const touchdown = new THREE.Mesh(touchdownGeometry, touchdownMaterial);
-    touchdown.position.set(0, -3.8, -85);
+    touchdown.position.set(0, -3.8, -80);
     scene.add(touchdown);
 
 

--- a/component/youngHee.tsx
+++ b/component/youngHee.tsx
@@ -236,6 +236,19 @@ const YoungHee = ({
       });
     });
 
+    // 결승선 
+    const touchdownGeometry = new THREE.BoxGeometry(250, 10, 5);
+    const touchdownMaterial = new THREE.MeshBasicMaterial({
+      color: 0x00ff00,
+      side: THREE.DoubleSide,
+      transparent: true,
+      opacity: 0.5,
+    });
+    const touchdown = new THREE.Mesh(touchdownGeometry, touchdownMaterial);
+    touchdown.position.set(0, -3.8, -85);
+    scene.add(touchdown);
+
+
     //================================================================================================
     //광원
 


### PR DESCRIPTION
이 풀 리퀘스트는 씬에 터치다운 라인을 추가합니다. 선은 좌표(0, -3.8, -80)에 위치하며 폭은 250, 높이는 10, 깊이는 5입니다. 선의 색은 녹색이며 불투명도는 0.5입니다.