### PR TITLE
feat(squidname): 오징어 이름 가독성 향상, window resize, turn on mouse down

### DIFF
--- a/component/youngHee.tsx
+++ b/component/youngHee.tsx
@@ -107,9 +107,31 @@ const YoungHee = ({
     }
   };
 
+
+  function onWindowResize(this: Window, ev: UIEvent) {
+    if (myCamera.current) {
+      myCamera.current.aspect = window.innerWidth / window.innerHeight;
+      myCamera.current.updateProjectionMatrix();
+    }
+    if (rendererRef.current) {
+      rendererRef.current.setSize(window.innerWidth, window.innerHeight);
+      rendererRef.current.render(
+        useRefScene.current as THREE.Scene,
+        myCamera.current as THREE.Camera
+      );
+    }
+    labelRenderer.current.setSize(window.innerWidth, window.innerHeight);
+    labelRenderer.current.render(
+      useRefScene.current as THREE.Scene,
+      myCamera.current as THREE.Camera
+    );
+  }
+
+
   useEffect(() => {
     // 스페이바 스코를 이벤트 비활성화
     window.addEventListener("keydown", handleSpacebarPress);
+    window.addEventListener("resize", onWindowResize);
     const scene = new THREE.Scene();
     // setScene(scene);
     useRefScene.current = scene;
@@ -492,19 +514,13 @@ const YoungHee = ({
   }
 
   useEffect(() => {
-    if (canvasRef.current) {
-      canvasRef.current.addEventListener("mousedown", turnBack);
-      canvasRef.current.addEventListener("mouseup", turnFront);
-      // canvasRef.current.addEventListener('mouseleave', exitPaint);
-    }
+    labelRenderer.current.domElement.addEventListener("mousedown", turnBack);
+    labelRenderer.current.domElement.addEventListener("mouseup", turnFront);
 
     return () => {
-      if (canvasRef.current) {
         // Unmount 시 이벤트 리스터 제거
-        canvasRef.current.removeEventListener("mousedown", turnBack);
-        canvasRef.current.removeEventListener("mouseup", turnFront);
-        // canvasRef.current.removeEventListener('mouseleave', exitPaint);
-      }
+        labelRenderer.current.domElement.removeEventListener("mousedown", turnBack);
+        labelRenderer.current.domElement.removeEventListener("mouseup", turnFront);
     };
   }, [turnBack, turnFront]);
 

--- a/component/youngHee.tsx
+++ b/component/youngHee.tsx
@@ -487,10 +487,22 @@ const YoungHee = ({
 
       // 플레이어 이름
       const div = document.createElement("div");
-      div.className = "label";
+
+      div.className = "squidlabel";
+      div.style.color = "black";
+      div.style.width= "100px";
+      div.style.height = "30px";
+      div.style.backgroundColor = "rgba(255, 255, 255, 0.3)";
+      div.style.borderRadius = "5px";
+      div.style.padding = "5px";
+      div.style.textAlign = "center";
+      div.style.color = "black";
+      div.style.fontSize = "20px";
+      div.style.textShadow = "1px 1px 1px rgb(0,0,0,0.5)";
       div.textContent = name;
+
       const label = new CSS2DObject(div);
-      label.position.set(0, 1, 0);
+      label.position.set(0, 4.5, 0);
       object.scene.add(label);
 
       //그림자 생성
@@ -767,17 +779,6 @@ const YoungHee = ({
           height: 100vh;
           display: block;
           background-color: #437185;
-        }
-        .label {
-          width: 100px;
-          height: 30px;
-          background-color: rgba(255, 255, 255, 0.7);
-          border-radius: 5px;
-          padding: 5px;
-          text-align: center;
-          color: black;
-          font-size: 20px;
-          font-weight: bold;
         }
       `}</style>
     </>


### PR DESCRIPTION
이 풀 리퀘스트는 창 크기를 조정할 때 전체 화면 크기를 유지하고 텍스트 위치를 보존하는 기능을 추가합니다. 또한 배경색, 테두리 반경, 텍스트 그림자를 추가하여 오징어 이름의 가독성을 개선합니다. 이벤트 리스너를 `canvasRef`가 아니라 `labelRenderer`에 달아 mouse down시에 영희 얼굴이 돌아가도록 만들었습니다.