### PR TITLE
feat: change List of player in Host page into Table

### DIFF
--- a/app/player/page.tsx
+++ b/app/player/page.tsx
@@ -200,8 +200,8 @@ export default function Player() {
         if (playerNickname === null || playerNickname === '') {
             alert('닉네임을 입력해주세요.');
             return;
-        } else if (playerNickname.length > 10) {
-            alert('닉네임은 10자 미만으로 입력해주세요.');
+        } else if (playerNickname.length > 5) {
+            alert('닉네임은 5글자 이하로 입력해주세요.');
             return;
         }
 

--- a/app/playerComponent/redGreenPlayer.tsx
+++ b/app/playerComponent/redGreenPlayer.tsx
@@ -103,22 +103,68 @@ export default function RedGreenPlayer({ roomId, socket, length, win_num, total_
         socket.on('game_finished', (res) => {
             setModalHeader('게임 끝!');
             setOpen(true);
-            setModalContent(<List
-                sx={{
-                  width: '100%',
-                  maxWidth: 360,
-                  bgcolor: '#f2f2f2',
-                  position: 'relative',
-                  overflow: 'auto',
-                  maxHeight: 300,
-                  '& ul': { padding: 0 },
-                }}
-                subheader={<li />}
-              >{res.player_info.map((player : all_player, index : number)=>{
-                const elapsedTime = timeCheck(new Date(player.elapsed_time)); //게임 시간 계산
-                const playerFixedDistance = player.distance>length?length:player.distance;
-                return <ListItem key={`item-${index}`}><div style={{backgroundColor: player.name === localStorage.getItem('nickname')?"#ffd400":'#f2f2f2'}}>{index+1}등: {player.name} / {playerFixedDistance} / {elapsedTime??''} / {player.state}</div></ListItem>
-            })}</List>);
+            setModalContent(
+                <table
+                    style={{
+                        width: '100%',
+                        maxWidth: 360,
+                        borderCollapse: 'collapse',
+                        backgroundColor: '#f2f2f2',
+                    }}
+                    >
+                    <thead>
+                        <tr>
+                        <th>순위</th>
+                        <th>이름</th>
+                        <th>거리</th>
+                        <th>시간</th>
+                        <th>상태</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {res.player_info.map((player: all_player, index: number) => {
+                        const elapsedTime = timeCheck(new Date(player.elapsed_time));
+                        const playerFixedDistance =
+                            player.distance > length ? length : player.distance;
+
+                        return (
+                            <tr key={`item-${index}`}>
+                            <td
+                                style={{
+                                backgroundColor:
+                                    player.name === localStorage.getItem('nickname')
+                                    ? '#ffd400'
+                                    : '#f2f2f2',
+                                }}
+                            >
+                                {index + 1}등
+                            </td>
+                            <td>{player.name}</td>
+                            <td>{playerFixedDistance}</td>
+                            <td>{elapsedTime ?? ''}</td>
+                            <td>{player.state}</td>
+                            </tr>
+                        );
+                        })}
+                    </tbody>
+                    </table>
+            // <List
+            //     sx={{
+            //       width: '100%',
+            //       maxWidth: 360,
+            //       bgcolor: '#f2f2f2',
+            //       position: 'relative',
+            //       overflow: 'auto',
+            //       maxHeight: 300,
+            //       '& ul': { padding: 0 },
+            //     }}
+            //     subheader={<li />}
+            //   >{res.player_info.map((player : all_player, index : number)=>{
+            //     const elapsedTime = timeCheck(new Date(player.elapsed_time)); //게임 시간 계산
+            //     const playerFixedDistance = player.distance>length?length:player.distance;
+            //     return <ListItem key={`item-${index}`}><div style={{backgroundColor: player.name === localStorage.getItem('nickname')?"#ffd400":'#f2f2f2'}}>{index+1}등: {player.name} / {playerFixedDistance} / {elapsedTime??''} / {player.state}</div></ListItem>
+            // })}</List>
+            );
         });
         
         //통과

--- a/app/redGreen/page.tsx
+++ b/app/redGreen/page.tsx
@@ -201,7 +201,52 @@ export default function RedGreen({socket}: {socket : Socket}) {
           <div>
             <div className="winnerInfo">
               <div className="modalText">
-              <List
+              <table
+                style={{
+                  width: '100%',
+                  maxWidth: 360,
+                  borderCollapse: 'collapse',
+                  backgroundColor: '#f2f2f2',
+                }}
+              >
+                <thead>
+                  <tr>
+                    <th>순위</th>
+                    <th>이름</th>
+                    <th>거리</th>
+                    <th>시간</th>
+                    <th>상태</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {player_info.map((player: playerInfo, index: number) => {
+                    const elapsedTime = timeCheck(new Date(player.elapsed_time));
+                    const playerFixedDistance =
+                      player.distance > gameInfo[1] ? gameInfo[1] : player.distance;
+
+                    return (
+                      <tr key={`item-${index}`}>
+                        <td
+                          style={{
+                            backgroundColor:
+                              index + 1 <= gameInfo[0] ? '#ffd400' : '#f2f2f2',
+                            borderRadius: '5px',
+                            fontWeight: index + 1 <= gameInfo[0] ? 900 : 400,
+                            color: index + 1 <= gameInfo[0] ? 'black' : 'gray',
+                          }}
+                        >
+                          {index + 1}등
+                        </td>
+                        <td>{player.name}</td>
+                        <td>{playerFixedDistance}</td>
+                        <td>{elapsedTime ?? ''}</td>
+                        <td>{player.state}</td>
+                      </tr>
+                    );
+                  })}
+                </tbody>
+              </table>
+              {/* <List
                 sx={{
                   width: '100%',
                   maxWidth: 360,
@@ -227,7 +272,7 @@ export default function RedGreen({socket}: {socket : Socket}) {
                   </div>
                 </ListItem>)
             })}
-            </List>
+            </List> */}
               </div>
             </div>
             <Button onClick={leaveGame}>게임 끝내기</Button>


### PR DESCRIPTION
host 화면에서 List로 표시되던 순위결과를 경계선이 없는 Table로 바꾸었습니다.

Player화면에서 순위 결과도 테이블로 바꾸는 것을 고려해봤지만 닉네임이 긴 경우에  1인당 결과가 2줄에 걸쳐 표시되는 일도 있어서 PC 화면만큼 보기 좋지는 않아서 적용을 고민중입니다.