### PR TITLE
무궁화게임 새로고침하면 바로 끝나는 문제 해결

### DIFF
--- a/app/gamePage/page.tsx
+++ b/app/gamePage/page.tsx
@@ -131,12 +131,13 @@ export default function QR() {
         };
     }, []);
 
-
         const makeRoom = (acc_token: string) => {
             const game_t = JSON.parse(localStorage.getItem('game') || 'null');
             socket.current.emit('make_room', {
-                goalDistance : redGreenInfo[1],
-                winnerNum : redGreenInfo[0],
+                // goalDistance : redGreenInfo[1],
+                // winnerNum : redGreenInfo[0],
+                goalDistance : JSON.parse(localStorage.getItem('redGreenInfo') || 'null')[1],
+                winnerNum : JSON.parse(localStorage.getItem('redGreenInfo') || 'null')[0],
                 game_type: game_t[0],
                 user_num: game_t[1],
                 answer: answer,


### PR DESCRIPTION
# 원인
- gameSelect에서 지정한 인원수를 gamePage에서 못 받아오는게 문제였다.
- 즉, jotai atom이 못 받아왔다.

# 해결
localStorage에서 get으로 받아오게 하였다.