### PR TITLE
이모티콘 배열 최적화 방식 변경

### DIFF
--- a/app/gamePage/page.tsx
+++ b/app/gamePage/page.tsx
@@ -48,6 +48,7 @@ export default function QR() {
     const [emotions, setEmotions] = useState<emotion[]>([]);
     const [redGreenInfo, ] = useAtom(redGreenInfoAtom);
     const [isStart, setIsStart] = useAtom(redGreenStartAtom);
+    const curEmo = useRef(emotions)
     interface emotion {
         x: number;
         y: number;
@@ -197,8 +198,8 @@ export default function QR() {
                     randomY = Math.floor(Math.random() * window.innerHeight);
                 }
 
-                if(emotions.length > 20){
-                    setEmotions((prevEmotions) => [...prevEmotions.slice(1),{ x: randomX, y: randomY, emotion: emotion }]);
+                if(curEmo.current.length > 200){
+                    setEmotions((prevEmotions) => [...prevEmotions.slice(150),{ x: randomX, y: randomY, emotion: emotion }]);
                 }
                 else 
                     setEmotions((prevEmotions) => [...prevEmotions, { x: randomX, y: randomY, emotion: emotion }]);
@@ -207,10 +208,7 @@ export default function QR() {
         },[]);    
 
         useEffect(()=>{
-            console.log(emotions.length)
-            if(emotions.length>200){
-                setEmotions([])
-            }
+            curEmo.current = emotions
         },[emotions])
 
         return (<>


### PR DESCRIPTION
# 기존
기존에는 useEffect로 배열의 크기가 200이 넘어가면 emotions 배열을 전부 초기화 했다.
이렇게 했을 땐  초기화 되기 직전에 사용자가 보낸 이모티콘은 초기화 과정 중에 씹히게 된다.

# 해결
useRef를 사용하여 emotions의 배열의 현재의 길이를 가져올 수 있게 하여 배열의 크기가 200이 되면 앞의 150개를 자르고 뒤에 50개만 남기게 하여 배열을 최적화도 시키면서 초기화 전 50개의 이모티콘에 대해서도 씹히지 않음을 보장하였다.